### PR TITLE
✨ 로그인 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-day-picker": "^9.12.0",
         "react-dom": "19.2.1",
         "react-toastify": "^11.0.5",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7163,6 +7164,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-day-picker": "^9.12.0",
     "react-dom": "19.2.1",
     "react-toastify": "^11.0.5",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,68 +1,123 @@
 "use client";
 
-import AuthForm from "@/components/auth/AuthForm";
-import kakao from "@/assets/auth/kakao.svg";
-import google from "@/assets/auth/google.svg";
-import BBlogoSet from "@/assets/common/BBlogoSet.svg";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 
-import { useRouter } from "next/navigation";
+import AuthForm from "@/components/auth/AuthForm";
 import Input from "@/components/common/Input";
 import Button from "@/components/common/Button";
 import DashDivider from "@/components/common/DashDivider";
-import { signin } from "@/features/auth/api/auth.api";
+
+import kakao from "@/assets/auth/kakao.svg";
+import google from "@/assets/auth/google.svg";
+import BBlogoSet from "@/assets/common/BBlogoSet.svg";
+
+import { useSignIn } from "@/features/auth/hooks/useSignIn";
+import { NoAuthOnly } from "@/features/auth/model/auth.guard";
 
 export default function LoginPage() {
-  const route = useRouter();
-  const handleTestLogin = async () => {
-    try {
-      const result = await signin({
-        email: "test@test.com",
-        password: "asdf1234!",
-      });
+  return (
+    <NoAuthOnly>
+      <LoginForm />
+    </NoAuthOnly>
+  );
+}
 
-      alert("로그인 요청 보냄");
-      console.log("result:", result);
-    } catch (e) {
-      console.error(e);
-      alert("로그인 실패");
-    }
+function LoginForm() {
+  const router = useRouter();
+  const signIn = useSignIn();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (signIn.isPending) return;
+
+    setErrorMsg(null);
+
+    signIn.mutate(
+      { email, password },
+      {
+        onSuccess: () => {
+          alert("로그인 성공");
+          router.push("/");
+        },
+        onError: (error: any) => {
+          const msg = error?.response?.data?.msg ?? "이메일 또는 비밀번호를 확인해주세요.";
+          setErrorMsg(msg);
+        },
+      }
+    );
   };
   return (
-    <>
-      <AuthForm>
+    <AuthForm>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* 로고 */}
         <div className="flex justify-center">
           <Image
             src={BBlogoSet}
             alt="BBlogoBackground"
-            className="cursor-pointer justify-center"
-            onClick={() => route.push("/")}
+            className="cursor-pointer"
+            onClick={() => router.push("/")}
           />
         </div>
-        <Input type="email" placeholder="이메일" />
-        <Input type="password" placeholder="비밀번호" />
+
+        {/* 이메일 */}
+        <Input
+          type="email"
+          placeholder="이메일"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+
+        {/* 비밀번호 */}
+        <Input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+
+        {/* 에러 메시지 */}
+        {errorMsg && <p className="text-center text-sm text-red-600">{errorMsg}</p>}
+
+        {/* 로그인 버튼 */}
         <Button
-          onClick={handleTestLogin}
+          type="submit"
+          disabled={signIn.isPending}
           className="bg-custom-orange drop-shadow-[4px_4px_0_rgba(0,0,0,1)]"
         >
-          로그인
+          {signIn.isPending ? "로그인 중..." : "로그인"}
         </Button>
+
         <DashDivider label="또는" />
+
+        {/* 소셜 로그인 */}
         <Button className="shadow-flat bg-yellow-300">
           <Image src={kakao} alt="kakao" className="mr-2" />
           <span>카카오 로그인</span>
         </Button>
+
+        <Button className="shadow-flat bg-green-500">
+          <span>N 네이버 로그인</span>
+        </Button>
+
         <Button className="shadow-flat">
           <Image src={google} alt="google" className="mr-2" />
           <span>Google 로그인</span>
         </Button>
+
+        {/* 회원가입 이동 */}
         <div className="flex justify-center">
           <span className="text-border-sub mr-2">아직 회원이 아니신가요?</span>
-          <span className="cursor-pointer text-red-700" onClick={() => route.push("/signup")}>
+          <span className="cursor-pointer text-red-700" onClick={() => router.push("/signup")}>
             회원가입
           </span>
         </div>
-      </AuthForm>
-    </>
+      </form>
+    </AuthForm>
   );
 }

--- a/src/features/auth/api/auth.api.ts
+++ b/src/features/auth/api/auth.api.ts
@@ -3,10 +3,20 @@ import type { UserSigninRequest, UserSigninResponse } from "../types/auth.types"
 
 export async function signin(payload: UserSigninRequest) {
   const res = await apiClient.post<UserSigninResponse>("/api/v1/users/signin", payload);
+  return res.data;
+}
 
-  console.log("[signin] status:", res.status);
-  console.log("[signin] data:", res.data);
-  console.log("[signin] headers:", res.headers);
+export async function signout() {
+  const res = await apiClient.get("/api/v1/users/signout");
+  return res.data;
+}
 
+export async function getMe() {
+  const res = await apiClient.get("/api/v1/users/me");
+  return res.data;
+}
+
+export async function refreshToken() {
+  const res = await apiClient.get("/api/v1/users/refresh");
   return res.data;
 }

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMe } from "../api/auth.api";
+
+export function useMe() {
+  return useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+    retry: false,
+  });
+}

--- a/src/features/auth/hooks/useSignIn.ts
+++ b/src/features/auth/hooks/useSignIn.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { signin } from "../api/auth.api";
+
+export function useSignIn() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: signin,
+    onSuccess: async () => {
+      // 로그인 성공하면 me를 다시 받아오게 해서 화면 갱신
+      await qc.invalidateQueries({ queryKey: ["me"] });
+    },
+  });
+}

--- a/src/features/auth/hooks/useSignOut.ts
+++ b/src/features/auth/hooks/useSignOut.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { signout } from "../api/auth.api";
+
+export function useSignOut() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: signout,
+    onSuccess: () => {
+      // me 캐시를 비워서 즉시 비로그인 상태로
+      qc.removeQueries({ queryKey: ["me"] });
+    },
+  });
+}

--- a/src/features/auth/model/auth.guard.tsx
+++ b/src/features/auth/model/auth.guard.tsx
@@ -1,0 +1,38 @@
+// src/features/auth/model/auth.guard.tsx
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useMe } from "../hooks/useMe";
+
+//  로그인 필요한 페이지용
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { data, isLoading } = useMe();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !data) {
+      alert("로그인이 필요합니다");
+      router.replace("/auth/login");
+    }
+  }, [isLoading, data, router]);
+
+  if (isLoading || !data) return null;
+  return <>{children}</>;
+}
+
+// 로그인 페이지 접근 차단용. 로그인 된 상태에서 못 접근하게
+export function NoAuthOnly({ children }: { children: React.ReactNode }) {
+  const { data, isLoading } = useMe();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && data) {
+      alert("로그인 상태입니다");
+      router.replace("/");
+    }
+  }, [isLoading, data, router]);
+
+  if (isLoading) return null;
+  return <>{children}</>;
+}

--- a/src/features/auth/model/auth.store.ts
+++ b/src/features/auth/model/auth.store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+type AuthState = {
+  user: User | null;
+  isHydrated: boolean; // false: 아직 me() 확인 중, true: me() 확인 완료. 진짜 로그인 여부 판단 가능
+
+  setUser: (user: User | null) => void;
+  setHydrated: (v: boolean) => void;
+
+  logoutLocal: () => void;
+};
+
+export const useAuthStore = create<AuthState>(set => ({
+  user: null,
+  isHydrated: false,
+
+  setUser: user => set({ user }),
+  setHydrated: v => set({ isHydrated: v }),
+
+  logoutLocal: () => set({ user: null }),
+}));

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -16,3 +16,12 @@ export interface UserSigninResponse {
     };
   };
 }
+
+export interface UserRefreshResponse {
+  resultCode: string;
+  msg: string;
+  data: {
+    accessToken: string;
+    expiresIn: number;
+  };
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,7 @@
-import axios from "axios";
+import { refreshToken } from "@/features/auth/api/auth.api";
+import { UserRefreshResponse } from "@/features/auth/types/auth.types";
+import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+// import { is } from "date-fns/locale";
 
 export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -7,3 +10,85 @@ export const apiClient = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+let isRefreshing = false;
+let refreshPromise: Promise<UserRefreshResponse> | null = null;
+
+// refresh 중에 들어온 요청들 큐에 쌓아두기.... refresh 끝나면 다시 실행
+type Pending = {
+  resolve: () => void; // refresh 성공했을 때
+  reject: (err: unknown) => void; // refresh 실패했을 때, 너도 실패 처리
+};
+let pendingQueue: Pending[] = [];
+
+//
+
+// refresh 끝나면 큐에 있는 모든 요청을 실행
+function flushQueue(error?: unknown) {
+  pendingQueue.forEach(({ resolve, reject }) => {
+    if (error) reject(error);
+    else resolve();
+  });
+  pendingQueue = [];
+}
+
+const REFRESH_PATH = "/api/v1/users/refresh"; // refresh 요청은 401처리에서 예외시켜야 하니까. 안그럼 무한루프 돈다.
+
+apiClient.interceptors.response.use(
+  response => response, // 성공이면 걍 통과
+  async (error: AxiosError) => {
+    const status = error.response?.status;
+    const originalRequest = error.config as
+      | (InternalAxiosRequestConfig & { _retry?: boolean })
+      | undefined; // 싪패한 요청의 설정을 담아놓음. 다시 실행할거니까
+
+    // 응답 자체가 없으면(네트워크 문제 등) 여기서 끝
+    if (!originalRequest) return Promise.reject(error);
+
+    // 401 아니면 그대로 던짐
+    if (status !== 401) return Promise.reject(error);
+
+    // refresh 요청에서 401이 나면 복구불가. 로그아웃 처리 대상
+    if (originalRequest.url?.includes(REFRESH_PATH)) {
+      return Promise.reject(error);
+    }
+
+    // 이미 재시도한 요청이면 무한루프 방지
+    if (originalRequest._retry) {
+      return Promise.reject(error);
+    }
+    originalRequest._retry = true;
+
+    // ============================
+    // 이미 refresh 중이면 기다리기
+    if (isRefreshing) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          pendingQueue.push({ resolve, reject });
+        });
+        return apiClient(originalRequest);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+
+    // refresh >>>>
+    isRefreshing = true;
+    refreshPromise = refreshToken();
+
+    try {
+      await refreshPromise;
+      // refresh 성공 : 대기중인 요청들 풀기
+      flushQueue();
+      return apiClient(originalRequest);
+    } catch (refreshErr) {
+      // refresh 실패 : 대기중인 요청들 전부 실패 처리
+      flushQueue(refreshErr);
+      // 로그아웃 트리거 넣어야댐
+      return Promise.reject(refreshErr);
+    } finally {
+      isRefreshing = false;
+      refreshPromise = null;
+    }
+  }
+);

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,0 +1,10 @@
+type User = {
+  id: number;
+  email: string;
+  nickname: string;
+  birthDate: string;
+  image: string | null;
+  createDate: string;
+  modifyDate: string;
+  bizz: number;
+};


### PR DESCRIPTION
## 연관된 이슈
<!--#이슈번호, #이슈번호-->
Closes #78 

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
로그인 페이지 제출폼으로 변경
새로고침해도 쿠키 유지
에러 msg 표시
공통 axios(apiClient)에 리프레시 토큰 로직을 포함
로그인 여부에 따른 접근 가드 컴포넌트화 (auth.guard.tsx)


## 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
로그아웃은 훅 잡아뒀고 로그아웃 버튼 생기면 연결하겠습니다.
변경파일 겹치면서 충돌이 많이 생길거같아 가드(requireAuth, noAuthOnly)는 페이지 권한에 따라 작업하시는 분이 추가하시면 되겠습니다.