### PR TITLE
♻️ client, server api fetch 방식으로 수정 ( 검색, 목록, 상세, 작성)

### DIFF
--- a/src/components/product/ProductInfo.tsx
+++ b/src/components/product/ProductInfo.tsx
@@ -82,7 +82,7 @@ export default function ProductInfo({ productId }: { productId: string }) {
                   <>
                     <div className="text-title-sub font-bold">경매 시작</div>
                     <div className="text-title-main-dark">
-                      {formatDateTime(product?.liveTIem || "")}
+                      {formatDateTime(product?.liveTime || "")}
                     </div>
                   </>
                 )}

--- a/src/components/search/SearchPageCliet.tsx
+++ b/src/components/search/SearchPageCliet.tsx
@@ -31,7 +31,7 @@ export default function SearchPageClient() {
     });
   };
 
-  const { cards, isLoading, isError, isFetching } = useLiveProductCards(params);
+  const { cards, isLoading, isError, error, isFetching } = useLiveProductCards(params);
 
   return (
     <>
@@ -46,7 +46,7 @@ export default function SearchPageClient() {
         isLoading={isLoading}
         isFetching={isFetching}
         hasSearched={hasSearched}
-        error={isError ? "검색하신 상품 목록이 없습니다." : null}
+        error={isError ? error.message : null}
         onPageChange={(page: number) => setParams(prev => ({ ...prev, page }))}
       />
 

--- a/src/features/auction/api/createAuctionProduct.api.ts
+++ b/src/features/auction/api/createAuctionProduct.api.ts
@@ -1,10 +1,18 @@
+import ClientApi from "@/lib/clientApi";
 import { apiClient } from "@/shared/api/client";
 
 export const createAuctionProduct = async (body: CreateAuctionProductRequest) => {
-  const res = await apiClient.post<ApiResponse<CreateAuctionProductResponse>>(
-    "/api/v1/auction/live",
-    body
-  );
+  // const res = await apiClient.post<ApiResponse<CreateAuctionProductResponse>>(
+  //   "/api/v1/auction/live",
+  //   body
+  // );
 
-  return res.data.data;
+  // return res.data.data;
+
+  const res = await ClientApi<CreateAuctionProductResponse>("/auction/live", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  return res.data;
 };

--- a/src/features/image/api/image.api.ts
+++ b/src/features/image/api/image.api.ts
@@ -1,9 +1,17 @@
+import ClientApi from "@/lib/clientApi";
 import { apiClient } from "@/shared/api/client";
 
-export const getPresignedUrl = async (body: GetPresignedUrlRequest): Promise<PresignedUrlData> => {
-  const res = await apiClient.post<ApiResponse<PresignedUrlData>>("/api/v1/images/upload", body);
+export const getPresignedUrl = async (body: GetPresignedUrlRequest) => {
+  // const res = await apiClient.post<ApiResponse<PresignedUrlData>>("/api/v1/images/upload", body);
 
-  return res.data.data;
+  // return res.data.data;
+
+  const res = await ClientApi("/images/upload", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  return res.data;
 };
 
 export const uploadToS3 = async (presignedUrl: string, file: File): Promise<void> => {

--- a/src/features/product/api/liveProduct.api.ts
+++ b/src/features/product/api/liveProduct.api.ts
@@ -1,24 +1,23 @@
-import { apiClient } from "@/shared/api/client";
-
-export interface GetLiveProductsParams {
-  name?: string;
-  category?: string;
-  minBidPrice?: number;
-  maxBidPrice?: number;
-  page: number;
-  size: number;
-}
+import ClientApi from "@/lib/clientApi";
+import { ApiError } from "next/dist/server/api-utils";
 
 export const getLiveProducts = async (params: GetLiveProductsParams) => {
-  const res = await apiClient.get<ApiResponse<LiveProductResponse>>("/api/v1/auction/live", {
-    params,
+  const res = await ClientApi<LiveProductResponse>("/auction/live", {
+    method: "GET",
+    params: { ...params },
   });
-  return res.data.data;
+
+  // if (res.resultCode) {
+  //   throw new ApiError(res.resultCode, res.msg);
+  // }
+
+  return res.data;
 };
 
 export const getLiveProduct = async (productId: number) => {
-  const res = await apiClient.get<ApiResponse<LiveProductDetail>>(
-    `/api/v1/auction/live/${productId}`
-  );
-  return res.data.data;
+  const res = await ClientApi<LiveProductDetail>(`/auction/live/${productId}`, {
+    method: "GET",
+  });
+
+  return res.data;
 };

--- a/src/features/product/hooks/useLiveProductCards.ts
+++ b/src/features/product/hooks/useLiveProductCards.ts
@@ -1,5 +1,4 @@
 import { useLiveProducts } from "./useLiveProducts";
-import { GetLiveProductsParams } from "../api/liveProduct.api";
 import { mapLiveProductToCard } from "../mapper/productCard";
 
 export function useLiveProductCards(params: GetLiveProductsParams) {

--- a/src/features/product/hooks/useLiveProducts.ts
+++ b/src/features/product/hooks/useLiveProducts.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getLiveProducts, GetLiveProductsParams } from "../api/liveProduct.api";
+import { getLiveProducts } from "../api/liveProduct.api";
 
 export function useLiveProducts(params: GetLiveProductsParams) {
   console.log("searchParams:", params);

--- a/src/features/product/types/liveProduct.type.d.ts
+++ b/src/features/product/types/liveProduct.type.d.ts
@@ -1,4 +1,13 @@
 // 라이브 상품 목록 조회 타입
+interface GetLiveProductsParams {
+  name?: string;
+  category?: string;
+  minBidPrice?: number;
+  maxBidPrice?: number;
+  page: number;
+  size: number;
+}
+
 interface LiveProduct {
   id: number;
   name: string;
@@ -30,7 +39,7 @@ interface LiveProductDetail {
   deliveryInclude: boolean;
   itemStatus: ItemCondition;
   auctionStatus: AuctionStatus;
-  liveTIem: string;
+  liveTime: string;
   directDealAvailable: boolean;
   region: string;
   preferredPlace: string;

--- a/src/lib/clientApi.ts
+++ b/src/lib/clientApi.ts
@@ -1,11 +1,26 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
-export default async function ClientApi(path: string, init: RequestInit) {
-  return await fetch(`${API_URL}${path}`, {
-    ...init,
+export default async function ClientApi<T>(
+  path: string,
+  init: ClientApiInit = {}
+): Promise<ApiResponse<T>> {
+  const { params, ...fetchInit } = init;
+  const qs = params
+    ? "?" +
+      new URLSearchParams(
+        Object.entries(params)
+          .filter(([, v]) => v !== undefined && v !== null)
+          .map(([k, v]) => [k, String(v)])
+      ).toString()
+    : "";
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1${path}${qs}`, {
+    ...fetchInit,
     headers: {
-      ...(init.headers || {}),
       "Content-Type": "application/json",
+      ...(fetchInit.headers || {}),
     },
     credentials: "include",
   });
+  if (!res.ok) {
+    throw new Error(`HTTP Error: ${res.status}`);
+  }
+  return (await res.json()) as ApiResponse<T>;
 }

--- a/src/lib/serverApi.ts
+++ b/src/lib/serverApi.ts
@@ -1,23 +1,69 @@
+// import { cookies } from "next/headers";
+
+// const API_URL = process.env.API_URL ?? "http://localhost:4000";
+
+// export async function ServerApi(path: string, init: RequestInit = {}) {
+//   const cookieStore = await cookies();
+//   const cookieHeader = cookieStore
+//     .getAll()
+//     .map((c) => `${c.name}=${c.value}`)
+//     .join("; ");
+
+//   const res = await fetch(`${API_URL}${path}`, {
+//     ...init,
+//     headers: {
+//       ...(init.headers || {}),
+//       Cookie: cookieHeader, // 브라우저 쿠키 그대로 전달
+//       "Content-Type": "application/json",
+//     },
+//     cache: "no-store", // 인증된 데이터는 보통 no-store
+//   });
+
+//   return res;
+// }
+
 import { cookies } from "next/headers";
 
-const API_URL = process.env.API_URL ?? "http://localhost:4000";
+type Params = Record<string, string | number | boolean | undefined>;
 
-export async function ServerApi(path: string, init: RequestInit = {}) {
+type ServerApiInit = RequestInit & {
+  params?: Params;
+};
+
+export async function ServerApi<T>(
+  path: string,
+  init: ServerApiInit = {}
+): Promise<ApiResponse<T>> {
+  const { params, ...fetchInit } = init;
+
+  const qs = params
+    ? "?" +
+      new URLSearchParams(
+        Object.entries(params)
+          .filter(([, v]) => v !== undefined && v !== null)
+          .map(([k, v]) => [k, String(v)])
+      ).toString()
+    : "";
+
   const cookieStore = await cookies();
   const cookieHeader = cookieStore
     .getAll()
-    .map((c) => `${c.name}=${c.value}`)
+    .map(c => `${c.name}=${c.value}`)
     .join("; ");
 
-  const res = await fetch(`${API_URL}${path}`, {
-    ...init,
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1${path}${qs}`, {
+    ...fetchInit,
     headers: {
-      ...(init.headers || {}),
-      Cookie: cookieHeader, // 브라우저 쿠키 그대로 전달
       "Content-Type": "application/json",
+      ...(fetchInit.headers || {}),
+      Cookie: cookieHeader,
     },
-    cache: "no-store", // 인증된 데이터는 보통 no-store
+    cache: fetchInit.cache ?? "no-store",
   });
 
-  return res;
+  if (!res.ok) {
+    throw new Error(`HTTP Error: ${res.status}`);
+  }
+
+  return (await res.json()) as ApiResponse<T>;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,3 +3,7 @@ interface ApiResponse<T> {
   msg: string;
   data: T;
 }
+type Params = Record<string, string | number | boolean | undefined>;
+type ClientApiInit = RequestInit & {
+  params?: Params;
+};


### PR DESCRIPTION
## 연관된 이슈
#94 

## 작업 내용
지연(일반) 상품은 이어서 진행할 예정입니다
- client, server api - {resultCode, msg, data} 타입으로 리턴 되게 수정
- client, server api - params 받을 수 있게 수정
- 라이브 상품 검색, 상세, 업로드 api 호출 관련 전반적 수정

## 확인 사항
- http status 관리는 client, server 공통 호출 함수 쪽에서
- resultCode는 각각 api 호출 함수 쪽에서