### PR TITLE
🐛이미지 업로드 타입 정의 오타, searchParams suspense로 감싸기

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,3 @@
-import { NoAuthOnly } from "@/features/auth/model/auth.guard";
-
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 
@@ -19,7 +19,9 @@ import Toast, { ToastType } from "@/components/common/Toast";
 export default function LoginPage() {
   return (
     <>
-      <LoginReasonHandler />
+      <Suspense fallback={null}>
+        <LoginReasonHandler />
+      </Suspense>
       <LoginForm />
     </>
   );

--- a/src/features/image/api/image.api.ts
+++ b/src/features/image/api/image.api.ts
@@ -1,7 +1,7 @@
 import ClientApi from "@/lib/clientApi";
 
 export const getPresignedUrl = async (body: GetPresignedUrlRequest) => {
-  const res = await ClientApi("/images/upload", {
+  const res = await ClientApi<PresignedUrlData>("/images/upload", {
     method: "POST",
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
## 연관된 이슈
이슈 없이 작업 했습니다.

## 작업 내용
- 이미지 업로드 api 함수에 타입 정의 오타
- login에서 사용되는 searchParams, Suspense로 감싸기